### PR TITLE
Removes the CoC button

### DIFF
--- a/src/layouts/home.hbs
+++ b/src/layouts/home.hbs
@@ -19,11 +19,6 @@
 						<h3><img class="" src="{{uiRootPath}}/img/github.svg">Contribute</h3>
 					</span>
 				</a>
-				<a class="btn-panel" href="https://www.lightbend.com/conduct">
-					<span>
-						<h3><img class="" src="{{uiRootPath}}/img/code-of-conduct.svg">Code of Conduct</h3>
-					</span>
-				</a>
         <a class="btn-panel" href="https://discuss.lightbend.com/c/cloudflow">
 					<span>
 						<h3><img class="" src="./_/img/discuss.svg">Discuss</h3>


### PR DESCRIPTION
As the CoC has been to the footer in #13, we can now remove this button from the top of the page.