### PR TITLE
remove link checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: node_js
 node_js: "lts/*"
 
 before_script:
-  - npm install -g gulp-cli link-checker
+  - npm install -g gulp-cli
 
 script:
   - gulp preview:build bundle:pack
-  - link-checker public --http-redirects=1 --external-only
 
 cache:
   yarn: true


### PR DESCRIPTION
This PR removes the link checker script from the travisCI build. 
Looks like this script is not doing much for us anyway.