### PR TITLE
remove cloudflow enterprise references from the header and footer

### DIFF
--- a/src/partials/footer-nav.hbs
+++ b/src/partials/footer-nav.hbs
@@ -8,7 +8,6 @@
 			<li><a href="https://doc.akka.io/docs/akka-enhancements/current/akka-resilience-enhancements.html">Akka Resilience Enhancements</a></li>
 			<li><a href="https://doc.akka.io/docs/akka-enhancements/current/akka-persistence-enhancements.html">Akka Persistence Enhancements</a></li>
 			<li><a href="https://cloudflow.io/docs/current/">Cloudflow</a></li>
-			<li><a href="https://developer.lightbend.com/docs/cloudflow/current/">Cloudflow Enterprise Features</a></li>
 			<li><a href="https://developer.lightbend.com/docs/fortify/current/">Fortify SCA for Scala</a></li>
 			<li><a class="navbar-item" href="https://www.lagomframework.com/documentation/">Lagom Framework</a></li>
 			<li><a href="https://developer.lightbend.com/docs/console/current/">Lightbend Console</a></li>

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -20,7 +20,6 @@
               <div class="navbar-dropdown-col mm-col-two">
                 <a class="navbar-item" href="https://doc.akka.io/docs/akka-enhancements/current/akka-resilience-enhancements.html">Akka Resilience Enhancements</a>
                 <a class="navbar-item" href="https://doc.akka.io/docs/akka-enhancements/current/akka-persistence-enhancements.html">Akka Persistence Enhancements</a>
-                <a class="navbar-item" href="https://developer.lightbend.com/docs/cloudflow/current/">Cloudflow Enterprise Features</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/fortify/current/">Fortify SCA for Scala</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/console/current/">Lightbend Console</a>
                 <a class="navbar-item" href="https://developer.lightbend.com/docs/lightbend-platform/introduction/">Lightbend Platform Guide</a>           


### PR DESCRIPTION
We have been asked to remove all references of Cloudflow Enterprise from the website, including these links.
Could you review this and publish a new version?
(I need to check at some point how gulp works to see if we can automate the zipping part)