### PR TITLE
updated the zulip ‘Z’ so that it feels similar in size to other icons

### DIFF
--- a/src/img/zulip-white.svg
+++ b/src/img/zulip-white.svg
@@ -1,7 +1,12 @@
-<svg width="60px" height="60px" viewBox="0 0 256 298" preserveAspectRatio="xMidYMid" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
-<title>Zulip</title>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
 <desc></desc>
-<defs></defs>
-<path d="M1.243.829H220.79l.57 3.676-64 63.845H31.896L1.243.829" fill="#ffffff" class="svg-fill"/><path d="M100.039 227.417l-96-.62-3.625-3.108L220.79.83 253.1 67.52 100.04 227.417z" fill="#ffffff" class="svg-fill"/><path d="M220.375 223.69H.414l34.382 73.32h220.79l-35.211-73.32" fill="#ffffff" class="svg-fill"/>
+<path d="M10.1,6.8h34.4l0.1,0.6l-10,10H14.9L10.1,6.8" fill="#ffffff" class="svg-fill"/>
+<path d="M25.6,42.3l-15-0.1L10,41.7L44.5,6.8l5.1,10.5L25.6,42.3L25.6,42.3z" fill="#ffffff" class="svg-fill"/>
+<path d="M44.5,41.7H10l5.4,11.5H50L44.5,41.7" fill="#ffffff" class="svg-fill"/>
 </svg>

--- a/src/partials/zulip-white-svg.hbs
+++ b/src/partials/zulip-white-svg.hbs
@@ -1,6 +1,8 @@
-<svg width="60px" height="60px" viewBox="0 0 256 298" preserveAspectRatio="xMidYMid" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 60 60" style="enable-background:new 0 0 60 60;" xml:space="preserve">
 <title>Zulip</title>
 <desc></desc>
 <defs></defs>
-<path d="M1.243.829H220.79l.57 3.676-64 63.845H31.896L1.243.829" fill="#ffffff" class="svg-fill"/><path d="M100.039 227.417l-96-.62-3.625-3.108L220.79.83 253.1 67.52 100.04 227.417z" fill="#ffffff" class="svg-fill"/><path d="M220.375 223.69H.414l34.382 73.32h220.79l-35.211-73.32" fill="#ffffff" class="svg-fill"/>
+<path d="M10.1,6.8h34.4l0.1,0.6l-10,10H14.9L10.1,6.8" fill="#ffffff" class="svg-fill"/>
+<path d="M25.6,42.3l-15-0.1L10,41.7L44.5,6.8l5.1,10.5L25.6,42.3L25.6,42.3z" fill="#ffffff" class="svg-fill"/>
+<path d="M44.5,41.7H10l5.4,11.5H50L44.5,41.7" fill="#ffffff" class="svg-fill"/>
 </svg>


### PR DESCRIPTION
@RayRoestenburg this updates the SVG so that the 'Z' looks similar in size to the other icons:

![screenshot-localhost_5252-2020 10 29-08_47_34](https://user-images.githubusercontent.com/1418129/97597864-8a078d80-19c3-11eb-9c0c-91f7301eeae3.png)
